### PR TITLE
Update GeoLocationForPhoneGap.js

### DIFF
--- a/src/GeoLocationForPhoneGap/widget/GeoLocationForPhoneGap.js
+++ b/src/GeoLocationForPhoneGap/widget/GeoLocationForPhoneGap.js
@@ -78,8 +78,8 @@ define([
         },
 
         _geolocationSuccess: function(position) {
-            this._obj.set(this.latAttr, position.coords.latitude);
-            this._obj.set(this.longAttr, position.coords.longitude);
+            this._obj.set(this.latAttr, +position.coords.latitude.toFixed(8));
+            this._obj.set(this.longAttr, +position.coords.longitude.toFixed(8));
             this._executeMicroflow();
         },
 


### PR DESCRIPTION
position sometimes returns longitude or latitude with more than 8 decimal places. The longitude and latitude have to be saved to a decimal field, which as 8 decimal places maximum, so this will return an error. By fixing the longitude and latitude to 8 fixed places, this issue can be avoided.

https://mendixsupport.zendesk.com/agent/tickets/61300